### PR TITLE
test/임상 정보 조회 테스트

### DIFF
--- a/src/clinical/clinical.controller.spec.ts
+++ b/src/clinical/clinical.controller.spec.ts
@@ -1,0 +1,59 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClinicalController } from './clinical.controller';
+import { ClinicalService } from './clinical.service';
+import { Clinical } from './entities/clinical.entity';
+
+jest.mock('./clinical.service');
+
+describe('ClinicalController', () => {
+  let controller: ClinicalController;
+  let service: ClinicalService;
+  const mockClinical: Clinical = {
+    id: 1,
+    GOODS_NAME: '상품 이름',
+    APPLY_ENTP_NAME: '신청자',
+    LAB_NAME: '실시 기관 이름',
+    CLINIC_EXAM_TITLE: '임상 시험 제목',
+    APPROVAL_TIME: new Date(),
+    created_At: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClinicalController],
+      providers: [ClinicalService],
+    }).compile();
+
+    controller = module.get<ClinicalController>(ClinicalController);
+    service = module.get<ClinicalService>(ClinicalService);
+  });
+
+  it('should bee defined', () => {
+    expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+  });
+
+  describe('find one', () => {
+    it('findone - success', async () => {
+      jest
+        .spyOn(service, 'findOneClinical')
+        .mockResolvedValueOnce(mockClinical);
+
+      const result = await controller.findOneClinical('1');
+      expect(result).toMatchObject(mockClinical);
+    });
+    it('find one - 해당 아이디를 가진 임상 정보가 없거나 유효한 임상 번호가 아님.', async () => {
+      jest.spyOn(service, 'findOneClinical').mockImplementation(() => {
+        throw new NotFoundException('유효한 임상 번호가 아닙니다.');
+      });
+
+      try {
+        await controller.findOneClinical('123');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe('유효한 임상 번호가 아닙니다.');
+      }
+    });
+  });
+});

--- a/src/clinical/clinical.controller.spec.ts
+++ b/src/clinical/clinical.controller.spec.ts
@@ -1,5 +1,6 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Step } from '../step/entities/step.entity';
 import { ClinicalController } from './clinical.controller';
 import { ClinicalService } from './clinical.service';
 import { Clinical } from './entities/clinical.entity';
@@ -9,15 +10,22 @@ jest.mock('./clinical.service');
 describe('ClinicalController', () => {
   let controller: ClinicalController;
   let service: ClinicalService;
-  const mockClinical: Clinical = {
-    id: 1,
-    GOODS_NAME: '상품 이름',
-    APPLY_ENTP_NAME: '신청자',
-    LAB_NAME: '실시 기관 이름',
-    CLINIC_EXAM_TITLE: '임상 시험 제목',
-    APPROVAL_TIME: new Date(),
-    created_At: new Date(),
-  };
+
+  const mockClinical = new Clinical();
+  mockClinical.id = 1;
+  mockClinical.GOODS_NAME = '상품 이름';
+  mockClinical.APPLY_ENTP_NAME = '신청자';
+  mockClinical.LAB_NAME = '실시 기관 이름';
+  mockClinical.CLINIC_EXAM_TITLE = '임상 시험 제목';
+  mockClinical.APPROVAL_TIME = new Date();
+  mockClinical.created_At = new Date();
+
+  const mockStep = new Step();
+  mockStep.id = 1;
+  mockStep.name = '1상';
+  mockStep.created_At = new Date('2021-11-16');
+
+  mockClinical.step = mockStep;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -34,16 +42,14 @@ describe('ClinicalController', () => {
     expect(service).toBeDefined();
   });
 
-  describe('find one', () => {
-    it('findone - success', async () => {
-      jest
-        .spyOn(service, 'findOneClinical')
-        .mockResolvedValueOnce(mockClinical);
+  describe('findOneClinical', () => {
+    it('findOneClinical - success', async () => {
+      jest.spyOn(service, 'findOneClinical').mockResolvedValue(mockClinical);
 
       const result = await controller.findOneClinical('1');
       expect(result).toMatchObject(mockClinical);
     });
-    it('find one - 해당 아이디를 가진 임상 정보가 없거나 유효한 임상 번호가 아님.', async () => {
+    it('findOneClinical - 해당 아이디를 가진 임상 정보가 없거나 유효한 임상 번호가 아님.', async () => {
       jest.spyOn(service, 'findOneClinical').mockImplementation(() => {
         throw new NotFoundException('유효한 임상 번호가 아닙니다.');
       });
@@ -54,6 +60,35 @@ describe('ClinicalController', () => {
         expect(error).toBeInstanceOf(NotFoundException);
         expect(error.message).toBe('유효한 임상 번호가 아닙니다.');
       }
+    });
+  });
+
+  describe('getListClinical', () => {
+    it('getListClinical - success', async () => {
+      const query = {
+        page: '1',
+        GOODS_NAME: '이름',
+        APPROVAL_TIME: '2021-11-16',
+        step: '1상',
+      };
+      jest
+        .spyOn(service, 'getListClinical')
+        .mockResolvedValue({ count: 1, data: [mockClinical] });
+      const expectClinicalList = await controller.getListClinical(query);
+      expect(expectClinicalList.count).toBe(1);
+      expect(expectClinicalList.data).toStrictEqual([mockClinical]);
+    });
+    it('getListClinical - 검색 결과 없음', async () => {
+      expect.assertions(2);
+      jest
+        .spyOn(service, 'getListClinical')
+        .mockResolvedValue({ count: 0, data: [] });
+      const expectClinicalList = await controller.getListClinical({
+        page: '1',
+        APPROVAL_TIME: '2000-01-01',
+      });
+      expect(expectClinicalList.count).toBe(0);
+      expect(expectClinicalList.data).toStrictEqual([]);
     });
   });
 });

--- a/src/clinical/clinical.service.spec.ts
+++ b/src/clinical/clinical.service.spec.ts
@@ -1,30 +1,44 @@
+import { HttpService } from '@nestjs/axios';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Step } from '../step/entities/step.entity';
+import { StepService } from '../step/step.service';
 import { ClinicalRepository } from './clinical.repository';
 import { ClinicalService } from './clinical.service';
 import { Clinical } from './entities/clinical.entity';
 
 const mockClinicalRepository = () => ({
   findOne: jest.fn(),
+  getListClinical: jest.fn(),
 });
+
+jest.mock('../step/step.service');
 
 describe('ClinicalService', () => {
   let service: ClinicalService;
   let repository: ClinicalRepository;
-  const mockClinical: Clinical = {
-    id: 1,
-    GOODS_NAME: '상품 이름',
-    APPLY_ENTP_NAME: '신청자',
-    LAB_NAME: '실시 기관 이름',
-    CLINIC_EXAM_TITLE: '임상 시험 제목',
-    APPROVAL_TIME: new Date(),
-    created_At: new Date(),
-  };
+  const mockClinical = new Clinical();
+  mockClinical.id = 1;
+  mockClinical.GOODS_NAME = '상품 이름';
+  mockClinical.APPLY_ENTP_NAME = '신청자';
+  mockClinical.LAB_NAME = '실시 기관 이름';
+  mockClinical.CLINIC_EXAM_TITLE = '임상 시험 제목';
+  mockClinical.APPROVAL_TIME = new Date('2021-11-16');
+  mockClinical.created_At = new Date('2021-11-16');
+
+  const mockStep = new Step();
+  mockStep.id = 1;
+  mockStep.name = '1상';
+  mockStep.created_At = new Date('2021-11-16');
+
+  mockClinical.step = mockStep;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ClinicalService,
+        { provide: HttpService, useValue: { get: jest.fn(() => []) } },
+        StepService,
         {
           provide: ClinicalRepository,
           useFactory: mockClinicalRepository,
@@ -40,20 +54,51 @@ describe('ClinicalService', () => {
     expect(repository).toBeDefined();
   });
 
-  describe('find one', () => {
-    it('find one - success', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(mockClinical);
+  describe('findOneClinical', () => {
+    it('findOneClinical - success', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockClinical);
       const expectClinical = await service.findOneClinical(1);
       expect(expectClinical).toMatchObject(mockClinical);
     });
-    it('find one - 해당 아이디와 일치하는 값이 없음.', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(undefined);
+    it('findOneClinical - 해당 아이디와 일치하는 값이 없음.', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(undefined);
       try {
         await service.findOneClinical(3);
       } catch (error) {
         expect(error).toBeInstanceOf(NotFoundException);
         expect(error.message).toBe('유효한 임상 번호가 아닙니다.');
       }
+    });
+  });
+
+  describe('getListClinical', () => {
+    it('getListClinical - success', async () => {
+      expect.assertions(2);
+      jest
+        .spyOn(repository, 'getListClinical')
+        .mockResolvedValue({ count: 1, data: [mockClinical] });
+
+      const query = {
+        page: '1',
+        GOODS_NAME: '이름',
+        APPROVAL_TIME: '2021-11-16',
+        step: '1상',
+      };
+      const expectClinicalList = await service.getListClinical(query);
+      expect(expectClinicalList.count).toBe(1);
+      expect(expectClinicalList.data).toStrictEqual([mockClinical]);
+    });
+    it('getListClinical - 검색 결과 없음', async () => {
+      jest
+        .spyOn(repository, 'getListClinical')
+        .mockResolvedValue({ count: 0, data: [] });
+
+      const expectClinicalList = await service.getListClinical({
+        page: '1',
+        APPROVAL_TIME: '2000-01-01',
+      });
+      expect(expectClinicalList.count).toBe(0);
+      expect(expectClinicalList.data).toStrictEqual([]);
     });
   });
 });

--- a/src/clinical/clinical.service.spec.ts
+++ b/src/clinical/clinical.service.spec.ts
@@ -1,0 +1,59 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClinicalRepository } from './clinical.repository';
+import { ClinicalService } from './clinical.service';
+import { Clinical } from './entities/clinical.entity';
+
+const mockClinicalRepository = () => ({
+  findOne: jest.fn(),
+});
+
+describe('ClinicalService', () => {
+  let service: ClinicalService;
+  let repository: ClinicalRepository;
+  const mockClinical: Clinical = {
+    id: 1,
+    GOODS_NAME: '상품 이름',
+    APPLY_ENTP_NAME: '신청자',
+    LAB_NAME: '실시 기관 이름',
+    CLINIC_EXAM_TITLE: '임상 시험 제목',
+    APPROVAL_TIME: new Date(),
+    created_At: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClinicalService,
+        {
+          provide: ClinicalRepository,
+          useFactory: mockClinicalRepository,
+        },
+      ],
+    }).compile();
+    service = module.get<ClinicalService>(ClinicalService);
+    repository = module.get<ClinicalRepository>(ClinicalRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+    expect(repository).toBeDefined();
+  });
+
+  describe('find one', () => {
+    it('find one - success', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(mockClinical);
+      const expectClinical = await service.findOneClinical(1);
+      expect(expectClinical).toMatchObject(mockClinical);
+    });
+    it('find one - 해당 아이디와 일치하는 값이 없음.', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(undefined);
+      try {
+        await service.findOneClinical(3);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe('유효한 임상 번호가 아닙니다.');
+      }
+    });
+  });
+});

--- a/src/clinical/dto/Query.dto.ts
+++ b/src/clinical/dto/Query.dto.ts
@@ -3,29 +3,29 @@ import { IsOptional, IsString } from 'class-validator';
 export class QueryDto {
   @IsString()
   @IsOptional()
-  page: string;
+  page?: string;
 
   @IsString()
   @IsOptional()
-  GOODS_NAME: string;
+  GOODS_NAME?: string;
 
   @IsString()
   @IsOptional()
-  APPROVAL_TIME: string;
+  APPROVAL_TIME?: string;
 
   @IsString()
   @IsOptional()
-  LAB_NAME: string;
+  LAB_NAME?: string;
 
   @IsString()
   @IsOptional()
-  APPLY_ENTP_NAME: string;
+  APPLY_ENTP_NAME?: string;
 
   @IsString()
   @IsOptional()
-  CLINIC_EXAM_TITLE: string;
+  CLINIC_EXAM_TITLE?: string;
 
   @IsString()
   @IsOptional()
-  step: string;
+  step?: string;
 }


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩터링
- [x] 테스트

## 작업 개요
- 임상 조회에 대한 테스트 코드 작성

## 상세 내용
- 임상 정보을 조회하는 findOneClinical, getListClinical 메소드에 대한 테스트 코드를 작성했습니다.

## 집중 요망!
- clinical/dto/Query.dto.ts 의 선택 항목에 "?" 연산자를 추가했습니다.

resolves: #17